### PR TITLE
#164 save generator settings in local storage

### DIFF
--- a/src/view/password-manager/src/components/Generator/Context/ParameterContext.jsx
+++ b/src/view/password-manager/src/components/Generator/Context/ParameterContext.jsx
@@ -11,12 +11,24 @@ export function useParameterContextUpdate() {
     return useContext(ParameterContextUpdate)
 }
 
+const getLocalParameters = () => {
+    return localStorage.getItem('generator') ? JSON.parse(localStorage.getItem('generator')) : {}
+}
+
 export default function ParameterProvider(props) {
-    const [parameters, setParameters] = useState([])
-    const [length, setLength] = useState("4")
+    const savedParameters = getLocalParameters()
+    const [parameters, setParameters] = useState(savedParameters?.parameters || [])
+    const [length, setLength] = useState(savedParameters?.length || "4")
 
     const addParameter = (newParameter) => {
         setParameters(parameters => {
+            const oldParameters = getLocalParameters()
+            console.log(oldParameters)
+            localStorage.setItem('generator', JSON.stringify({
+                ...oldParameters,
+                parameters: [...(oldParameters.parameters ?? []), newParameter]
+            }))
+
             return [...parameters, newParameter]
         })
     }
@@ -27,12 +39,24 @@ export default function ParameterProvider(props) {
             // Deleting the parameter from the array.
             const parameterIndex = newParameters.indexOf(parameter)
             newParameters.splice(parameterIndex, 1)
+
+            const oldParameters = getLocalParameters()
+            localStorage.setItem('generator', JSON.stringify({
+                ...oldParameters,
+                parameters: [...newParameters]
+            }))
+            
             return newParameters
         })
     }
 
     const updateLength = (newLength) => {
         setLength(newLength)
+        const oldParameters = getLocalParameters()
+        localStorage.setItem('generator', JSON.stringify({
+            ...oldParameters,
+            length: newLength
+        }))
     }
 
     return (

--- a/src/view/password-manager/src/components/Generator/Generator.jsx
+++ b/src/view/password-manager/src/components/Generator/Generator.jsx
@@ -71,15 +71,15 @@ function PasswordGenerator() {
 }
 
 function GeneratorParameters() {
-    // State
-    const [useLower, setUseLower] = useState(false)
-    const [useUpper, setUseUpper] = useState(false)
-    const [useNumbers, setUseNumbers] = useState(false)
-    const [useSymbols, setUseSymbols] = useState(false)
-
     // Context
-    const length = useParameterContext().length
+    const {length, parameters} = useParameterContext()
     const update = useParameterContextUpdate()
+
+    // State
+    const [useLower, setUseLower] = useState(parameters.includes("LOWERCASE"))
+    const [useUpper, setUseUpper] = useState(parameters.includes("UPPERCASE"))
+    const [useNumbers, setUseNumbers] = useState(parameters.includes("NUMBERS"))
+    const [useSymbols, setUseSymbols] = useState(parameters.includes("SYMBOLS"))
 
     return (
         <div>


### PR DESCRIPTION
**Save generator settings in local storage.**
 
Save generator settings in `local storage` in order to access them later without further configuration.
 
What files are being created, modified, or deleted?
 
Modified: src/view/password-manager/src/components/Generator/Context/ParameterContext.jsx
Modified: src/view/password-manager/src/components/Generator/Generator.jsx
 
Give a summary for each file on why you are making these changes:

ParameterContext: Made changes in this file so the context can retrieve and modify local values.
Generator: This file was updated in order to configure the generator values on load.
 
Did you test these changes?

These changes were tested manually using the `dev tools`, checking the `application storage`.
 
Do these changes impact the application negatively in any way?

These changes shouldn't impact the application performance in any way